### PR TITLE
Initial implementation of stochastic muzero

### DIFF
--- a/muzero-general/models.py
+++ b/muzero-general/models.py
@@ -200,6 +200,33 @@ class MuZeroFullyConnectedNetwork(AbstractNetwork):
 
 
 ##################################
+###### Start Stochastic #######
+
+
+class MuZeroStochastic(AbstractNetwork):
+    def dynamics(self, encoded_state, action):
+        """
+        We augment this function to return a categorical distribution over next states
+
+        Returns:
+            probs (list): probability of next state
+            next_encoded_state  (list): next states
+            reward (list): reward associated with each next state
+        """
+        raise NotImplementedError
+
+    def recurrent_inference(self, encoded_state, action):
+        raise NotImplementedError(
+            'This function should not be implemented, \
+            the tree search should call dynamics and prediction separately \
+            for clarity in the bi-level tree search process.')
+        
+
+###### End Stochastic #######
+##################################
+
+
+##################################
 ############# ResNet #############
 
 

--- a/muzero-general/self_play_stochastic.py
+++ b/muzero-general/self_play_stochastic.py
@@ -1,0 +1,641 @@
+import math
+import time
+
+import numpy
+import ray
+import torch
+
+import models
+
+
+@ray.remote
+class SelfPlay:
+    """
+    Class which run in a dedicated thread to play games and save them to the replay-buffer.
+    """
+
+    def __init__(self, initial_checkpoint, Game, config, seed):
+        self.config = config
+        self.game = Game(seed)
+
+        # Fix random generator seed
+        numpy.random.seed(seed)
+        torch.manual_seed(seed)
+
+        # Initialize the network
+        self.model = models.MuZeroNetwork(self.config)
+        self.model.set_weights(initial_checkpoint["weights"])
+        self.model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model.eval()
+
+    def continuous_self_play(self, shared_storage, replay_buffer, test_mode=False):
+        while ray.get(
+            shared_storage.get_info.remote("training_step")
+        ) < self.config.training_steps and not ray.get(
+            shared_storage.get_info.remote("terminate")
+        ):
+            self.model.set_weights(ray.get(shared_storage.get_info.remote("weights")))
+
+            if not test_mode:
+                game_history = self.play_game(
+                    self.config.visit_softmax_temperature_fn(
+                        trained_steps=ray.get(
+                            shared_storage.get_info.remote("training_step")
+                        )
+                    ),
+                    self.config.temperature_threshold,
+                    False,
+                    "self",
+                    0,
+                )
+
+                replay_buffer.save_game.remote(game_history, shared_storage)
+
+            else:
+                # Take the best action (no exploration) in test mode
+                game_history = self.play_game(
+                    0,
+                    self.config.temperature_threshold,
+                    False,
+                    "self" if len(self.config.players) == 1 else self.config.opponent,
+                    self.config.muzero_player,
+                )
+
+                # Save to the shared storage
+                shared_storage.set_info.remote(
+                    {
+                        "episode_length": len(game_history.action_history) - 1,
+                        "total_reward": sum(game_history.reward_history),
+                        "mean_value": numpy.mean(
+                            [value for value in game_history.root_values if value]
+                        ),
+                    }
+                )
+                if 1 < len(self.config.players):
+                    shared_storage.set_info.remote(
+                        {
+                            "muzero_reward": sum(
+                                reward
+                                for i, reward in enumerate(game_history.reward_history)
+                                if game_history.to_play_history[i - 1]
+                                == self.config.muzero_player
+                            ),
+                            "opponent_reward": sum(
+                                reward
+                                for i, reward in enumerate(game_history.reward_history)
+                                if game_history.to_play_history[i - 1]
+                                != self.config.muzero_player
+                            ),
+                        }
+                    )
+
+            # Managing the self-play / training ratio
+            if not test_mode and self.config.self_play_delay:
+                time.sleep(self.config.self_play_delay)
+            if not test_mode and self.config.ratio:
+                while (
+                    ray.get(shared_storage.get_info.remote("training_step"))
+                    / max(
+                        1, ray.get(shared_storage.get_info.remote("num_played_steps"))
+                    )
+                    < self.config.ratio
+                    and ray.get(shared_storage.get_info.remote("training_step"))
+                    < self.config.training_steps
+                    and not ray.get(shared_storage.get_info.remote("terminate"))
+                ):
+                    time.sleep(0.5)
+
+        self.close_game()
+
+    def play_game(
+        self, temperature, temperature_threshold, render, opponent, muzero_player, save_gif=False
+    ):
+        """
+        Play one game with actions based on the Monte Carlo tree search at each moves.
+        """
+        game_history = GameHistory()
+        observation = self.game.reset()
+        game_history.action_history.append(0)
+        game_history.observation_history.append(observation)
+        game_history.reward_history.append(0)
+        game_history.to_play_history.append(self.game.to_play())
+
+        done = False
+
+        if render:
+            self.game.render()
+
+        if save_gif:
+            self.game.render_rgb()
+
+        with torch.no_grad():
+            while (
+                not done and len(game_history.action_history) <= self.config.max_moves
+            ):
+                assert (
+                    len(numpy.array(observation).shape) == 3
+                ), f"Observation should be 3 dimensionnal instead of {len(numpy.array(observation).shape)} dimensionnal. Got observation of shape: {numpy.array(observation).shape}"
+                assert (
+                    numpy.array(observation).shape == self.config.observation_shape
+                ), f"Observation should match the observation_shape defined in MuZeroConfig. Expected {self.config.observation_shape} but got {numpy.array(observation).shape}."
+                stacked_observations = game_history.get_stacked_observations(
+                    -1,
+                    self.config.stacked_observations,
+                )
+
+                # Choose the action
+                if opponent == "self" or muzero_player == self.game.to_play():
+                    root, mcts_info = MCTS(self.config).run(
+                        self.model,
+                        stacked_observations,
+                        self.game.legal_actions(),
+                        self.game.to_play(),
+                        True,
+                    )
+                    action = self.select_action(
+                        root,
+                        temperature
+                        if not temperature_threshold
+                        or len(game_history.action_history) < temperature_threshold
+                        else 0,
+                    )
+
+                    if render:
+                        print(f'Tree depth: {mcts_info["max_tree_depth"]}')
+                        print(
+                            f"Root value for player {self.game.to_play()}: {root.value():.2f}"
+                        )
+                else:
+                    action, root = self.select_opponent_action(
+                        opponent, stacked_observations
+                    )
+
+                observation, reward, done = self.game.step(action)
+
+                if render:
+                    print(f"Played action: {self.game.action_to_string(action)}")
+                    self.game.render()
+                
+                if save_gif:
+                    self.game.render_rgb()
+
+                game_history.store_search_statistics(root, self.config.action_space)
+
+                # Next batch
+                game_history.action_history.append(action)
+                game_history.observation_history.append(observation)
+                game_history.reward_history.append(reward)
+                game_history.to_play_history.append(self.game.to_play())
+
+        if save_gif:
+            self.game.save_gif()
+
+        return game_history
+
+    def close_game(self):
+        self.game.close()
+
+    def select_opponent_action(self, opponent, stacked_observations):
+        """
+        Select opponent action for evaluating MuZero level.
+        """
+        if opponent == "human":
+            root, mcts_info = MCTS(self.config).run(
+                self.model,
+                stacked_observations,
+                self.game.legal_actions(),
+                self.game.to_play(),
+                True,
+            )
+            print(f'Tree depth: {mcts_info["max_tree_depth"]}')
+            print(f"Root value for player {self.game.to_play()}: {root.value():.2f}")
+            print(
+                f"Player {self.game.to_play()} turn. MuZero suggests {self.game.action_to_string(self.select_action(root, 0))}"
+            )
+            return self.game.human_to_action(), root
+        elif opponent == "expert":
+            return self.game.expert_agent(), None
+        elif opponent == "random":
+            assert (
+                self.game.legal_actions()
+            ), f"Legal actions should not be an empty array. Got {self.game.legal_actions()}."
+            assert set(self.game.legal_actions()).issubset(
+                set(self.config.action_space)
+            ), "Legal actions should be a subset of the action space."
+
+            return numpy.random.choice(self.game.legal_actions()), None
+        else:
+            raise NotImplementedError(
+                'Wrong argument: "opponent" argument should be "self", "human", "expert" or "random"'
+            )
+
+    @staticmethod
+    def select_action(node, temperature):
+        """
+        Select action according to the visit count distribution and the temperature.
+        The temperature is changed dynamically with the visit_softmax_temperature function
+        in the config.
+        """
+        visit_counts = numpy.array(
+            [child.visit_count for child in node.children.values()], dtype="int32"
+        )
+        actions = [action for action in node.children.keys()]
+        if temperature == 0:
+            action = actions[numpy.argmax(visit_counts)]
+        elif temperature == float("inf"):
+            action = numpy.random.choice(actions)
+        else:
+            # See paper appendix Data Generation
+            visit_count_distribution = visit_counts ** (1 / temperature)
+            visit_count_distribution = visit_count_distribution / sum(
+                visit_count_distribution
+            )
+            action = numpy.random.choice(actions, p=visit_count_distribution)
+
+        return action
+
+
+# Game independent
+class MCTS:
+    """
+    Core Monte Carlo Tree Search algorithm.
+    To decide on an action, we run N simulations, always starting at the root of
+    the search tree and traversing the tree according to the UCB formula until we
+    reach a leaf node.
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+    def run(
+        self,
+        model,
+        observation,
+        legal_actions,
+        to_play,
+        add_exploration_noise,
+        override_root_with=None,
+    ):
+        """
+        At the root of the search tree we use the representation function to obtain a
+        hidden state given the current observation.
+        We then run a Monte Carlo Tree Search using only action sequences and the model
+        learned by the network.
+        """
+        if override_root_with:
+            root = override_root_with
+            root_predicted_value = None
+        else:
+            root = StateNode(0)
+            observation = (
+                torch.tensor(observation)
+                .float()
+                .unsqueeze(0)
+                .to(next(model.parameters()).device)
+            )
+            (
+                root_predicted_value,
+                reward,
+                policy_logits,
+                hidden_state,
+            ) = model.initial_inference(observation)
+            root_predicted_value = models.support_to_scalar(
+                root_predicted_value, self.config.support_size
+            ).item()
+            reward = models.support_to_scalar(reward, self.config.support_size).item()
+            assert (
+                legal_actions
+            ), f"Legal actions should not be an empty array. Got {legal_actions}."
+            assert set(legal_actions).issubset(
+                set(self.config.action_space)
+            ), "Legal actions should be a subset of the action space."
+            root.expand(
+                legal_actions,
+                to_play,
+                reward,
+                policy_logits,
+                hidden_state,
+            )
+
+        if add_exploration_noise:
+            root.add_exploration_noise(
+                dirichlet_alpha=self.config.root_dirichlet_alpha,
+                exploration_fraction=self.config.root_exploration_fraction,
+            )
+
+        min_max_stats = MinMaxStats()
+
+        max_tree_depth = 0
+        for _ in range(self.config.num_simulations):
+            virtual_to_play = to_play
+            node = root
+            search_path = [node]
+            current_tree_depth = 0
+
+            while node.expanded():
+                current_tree_depth += 1
+                action, node = node.select_child(min_max_stats, self.config)
+                search_path.append(node)
+
+                # Players play turn by turn
+                if virtual_to_play + 1 < len(self.config.players):
+                    virtual_to_play = self.config.players[virtual_to_play + 1]
+                else:
+                    virtual_to_play = self.config.players[0]
+
+            parent = search_path[-2]
+            if isinstance(node, StateNode):
+                # in other words, the parent is a TransitionNode
+
+                # A transition node will store the hidden state and reward of its child nodes
+                # we just need to retrieve it here
+                hidden_state = parent.child_hidden_states[action]
+                reward = parent.child_rewards[action]
+
+                policy_logits, value = model.prediction(hidden_state)
+
+                value = models.support_to_scalar(value, self.config.support_size).item()
+                reward = models.support_to_scalar(reward, self.config.support_size).item()
+                node.expand(
+                    self.config.action_space,
+                    virtual_to_play,
+                    reward,
+                    policy_logits,
+                    hidden_state,
+                )
+
+                self.backpropagate(search_path, value, virtual_to_play, min_max_stats)
+            elif isinstance(node, TransitionNode):
+                # in other words, the parent is a StateNode
+                probs, child_hidden_states, child_rewards = model.dynamics(
+                    parent.hidden_state, 
+                    torch.tensor([[action]]).to(parent.hidden_state.device),
+                )
+
+                node.expand(
+                    virtual_to_play,
+                    probs,
+                    child_hidden_states, 
+                    child_rewards,
+                )
+                # TODO: what is the value supposed to be for a transition node? 
+                #       It doesn't have a value
+
+                # TODO: confirm that we do not backpropagate when the last added node is a transition node
+                #       since it's phantom and does not have a value when it's newly added.
+
+            max_tree_depth = max(max_tree_depth, current_tree_depth)
+
+        extra_info = {
+            "max_tree_depth": max_tree_depth,
+            "root_predicted_value": root_predicted_value,
+        }
+        return root, extra_info
+
+    def backpropagate(self, search_path, value, to_play, min_max_stats):
+        """
+        At the end of a simulation, we propagate the evaluation all the way up the tree
+        to the root.
+        """
+        assert self.config.players == 1
+
+        for node in reversed(search_path):
+            node.value_sum += value
+            node.visit_count += 1
+            min_max_stats.update(node.reward + self.config.discount * node.value())
+
+            if isinstance(node, TransitionNode):
+                # no discounting through a transition node
+                value = value
+            elif isinstance(node, StateNode):
+                value = node.reward + self.config.discount * value
+
+
+class Node:
+    def __init__(self, prior):
+        self.visit_count = 0
+        self.to_play = -1
+        self.prior = prior
+        self.value_sum = 0
+        self.children = {}
+        self.hidden_state = None
+        self.reward = 0
+
+    def expanded(self):
+        return len(self.children) > 0
+
+    def value(self):
+        if self.visit_count == 0:
+            return 0
+        return self.value_sum / self.visit_count
+
+    def add_exploration_noise(self, dirichlet_alpha, exploration_fraction):
+        """
+        At the start of each search, we add dirichlet noise to the prior of the root to
+        encourage the search to explore new actions.
+        """
+        actions = list(self.children.keys())
+        noise = numpy.random.dirichlet([dirichlet_alpha] * len(actions))
+        frac = exploration_fraction
+        for a, n in zip(actions, noise):
+            self.children[a].prior = self.children[a].prior * (1 - frac) + n * frac
+
+
+class StateNode(Node):
+    def __init__(self, prior):
+        super().__init__(prior)
+
+    def expand(self, actions, to_play, reward, policy_logits, hidden_state):
+        """
+        We expand a node using the value, reward and policy prediction obtained from the
+        neural network.
+        """
+        self.to_play = to_play
+        self.reward = reward
+        self.hidden_state = hidden_state
+
+        policy_values = torch.softmax(
+            torch.tensor([policy_logits[0][a] for a in actions]), dim=0
+        ).tolist()
+        policy = {a: policy_values[i] for i, a in enumerate(actions)}
+        for action, p in policy.items():
+            self.children[action] = TransitionNode(p)
+
+    def select_child(self, min_max_stats, config):
+        """
+        Select the child with the highest UCB score.
+        """
+        max_ucb = max(
+            self.ucb_score(child, min_max_stats, config)
+            for action, child in self.children.items()
+        )
+        action = numpy.random.choice(
+            [
+                action
+                for action, child in self.children.items()
+                if self.ucb_score(child, min_max_stats, config) == max_ucb
+            ]
+        )
+        return action, self.children[action]
+
+    def ucb_score(self, child, min_max_stats, config):
+        """
+        The score for a node is based on its value, plus an exploration bonus based on the prior.
+        """
+        pb_c = (
+            math.log(
+                (self.visit_count + config.pb_c_base + 1) / config.pb_c_base
+            )
+            + config.pb_c_init
+        )
+        pb_c *= math.sqrt(self.visit_count) / (child.visit_count + 1)
+
+        prior_score = pb_c * child.prior
+
+        if child.visit_count > 0:
+            # Mean value Q
+            value_score = min_max_stats.normalize(
+                child.reward
+                + config.discount
+                * (child.value() if len(config.players) == 1 else -child.value())
+            )
+        else:
+            value_score = 0
+
+        return prior_score + value_score
+
+class TransitionNode(Node):
+    def __init__(self, prior):
+        super().__init__(prior)
+
+        self.child_hidden_states = []
+        self.child_rewards = []
+
+    def select_child(self, min_max_stats, config):
+        """
+        Select which stochastic transition to take (after selected an action)
+
+        Returns:
+            action
+            child (StateNode)
+            
+        """
+        # TODO: randomly sample transitions for now. 
+        # We probably want to do something between random sampling and
+        # distribution produced by the dynamics model
+        # to balance between exploration and exploitation
+        action = numpy.random.choice([
+            action for action, child in self.children.items()
+        ])
+        return action, self.children[action]
+
+    def expand(self, to_play, transition_probs, child_hidden_states, child_rewards):
+        """
+        We expand a node using the value, reward and policy prediction obtained from the
+        neural network.
+        """
+        self.to_play = to_play
+        
+        # a transition node is phantom, does not accumulate reward or have a hidden state
+        self.reward = 0.
+        self.hidden_state = None
+
+        # we temporarily stores the child states here. We can also directly
+        # construct the child (i.e. state) nodes with their hidden states and rewards
+        # but we currently defer that to the child node expand operation for consistency 
+        # with previous behavior
+        self.child_hidden_states = child_hidden_states
+        self.child_rewards = child_reward
+
+        for action, p in enumerate(transition_probs)
+            self.children[action] = StateNode(p)
+
+class GameHistory:
+    """
+    Store only usefull information of a self-play game.
+    """
+
+    def __init__(self):
+        self.observation_history = []
+        self.action_history = []
+        self.reward_history = []
+        self.to_play_history = []
+        self.child_visits = []
+        self.root_values = []
+        self.reanalysed_predicted_root_values = None
+        # For PER
+        self.priorities = None
+        self.game_priority = None
+
+    def store_search_statistics(self, root, action_space):
+        # Turn visit count from root into a policy
+        if root is not None:
+            sum_visits = sum(child.visit_count for child in root.children.values())
+            self.child_visits.append(
+                [
+                    root.children[a].visit_count / sum_visits
+                    if a in root.children
+                    else 0
+                    for a in action_space
+                ]
+            )
+
+            self.root_values.append(root.value())
+        else:
+            self.root_values.append(None)
+
+    def get_stacked_observations(self, index, num_stacked_observations):
+        """
+        Generate a new observation with the observation at the index position
+        and num_stacked_observations past observations and actions stacked.
+        """
+        # Convert to positive index
+        index = index % len(self.observation_history)
+
+        stacked_observations = self.observation_history[index].copy()
+        for past_observation_index in reversed(
+            range(index - num_stacked_observations, index)
+        ):
+            if 0 <= past_observation_index:
+                previous_observation = numpy.concatenate(
+                    (
+                        self.observation_history[past_observation_index],
+                        [
+                            numpy.ones_like(stacked_observations[0])
+                            * self.action_history[past_observation_index + 1]
+                        ],
+                    )
+                )
+            else:
+                previous_observation = numpy.concatenate(
+                    (
+                        numpy.zeros_like(self.observation_history[index]),
+                        [numpy.zeros_like(stacked_observations[0])],
+                    )
+                )
+
+            stacked_observations = numpy.concatenate(
+                (stacked_observations, previous_observation)
+            )
+
+        return stacked_observations
+
+
+class MinMaxStats:
+    """
+    A class that holds the min-max values of the tree.
+    """
+
+    def __init__(self):
+        self.maximum = -float("inf")
+        self.minimum = float("inf")
+
+    def update(self, value):
+        self.maximum = max(self.maximum, value)
+        self.minimum = min(self.minimum, value)
+
+    def normalize(self, value):
+        if self.maximum > self.minimum:
+            # We normalize only when we have set the maximum and minimum values
+            return (value - self.minimum) / (self.maximum - self.minimum)
+        return value


### PR DESCRIPTION
To extend MuZero to stochastic setting, we need to have:

- [x]  modify MCTS to handel stochastic transitions
- [ ] use a generative model as the underlying dynamics function

This PR includes initial progress in implementing the MCTS changes.
This is mostly done (I think? Did not test), according to the representation Sergio and I agreed on [here](https://docs.google.com/presentation/d/1EemYMfXwiAejwN0FuIWUlyj3p7NkA7RkHin31A1cdfM/edit#slide=id.gcf7a722a45_0_42)

tldr: we extend `Node` to `StateNode` and `Transition Node` to capture branching due to action and dynamics. We implement modified Selection/Transition/Expansion/Backup for `Transition Node`, while the `StateNode` mostly remain the same.